### PR TITLE
Add functions to manipulate image files

### DIFF
--- a/inc/libuimg/img.h
+++ b/inc/libuimg/img.h
@@ -82,5 +82,44 @@ Image_t * create_image (uint16_t width, uint16_t height, PixelFormat_t format);
  */
 void destroy_image (Image_t * img);
 
+/**
+ * @brief      Save an image to a (binary) file.
+ *
+ * The following elements are saved in the binary file, in order: width, height, pixel
+ * format, raw image data.
+ *
+ * @param[in]  img       The image to save.
+ * @param[in]  filepath  The path to the file where the image should be saved.
+ *
+ * @return     1 if successful, 0 otherwise.
+ */
+uint8_t save_image (Image_t * img, const char * filepath);
+
+/**
+ * @brief      Load an image from a (binary) file.
+ *
+ * An image will be created by this function, and it has to be freed later; if you wish
+ * to not use any dynamic allocations, use `load_static_image` instead.
+ *
+ * @param[in]  filepath  The path to the file where the image should be loaded from.
+ *
+ * @return     The loaded image structure if successful, NULL otherwise.
+ */
+Image_t * load_image (const char * filepath);
+
+/**
+ * @brief      Load an image from a (binary) file statically (without any allocations).
+ *
+ * The img parameter passed to this function should already be initialized correctly
+ * as no allocations will be performed; we expect the data buffer to be large enough to
+ * contain what is going to be loaded from the image file.
+ *
+ * @param[in]  img       The image structure to load to.
+ * @param[in]  filepath  The path to the file where the image should be loaded from.
+ *
+ * @return     1 if successful, 0 otherwise.
+ */
+uint8_t load_static_image (Image_t * img, const char * filepath);
+
 
 #endif

--- a/src/img.c
+++ b/src/img.c
@@ -1,23 +1,11 @@
 #include "libuimg/img.h"
 
 
-Image_t * create_image (uint16_t width, uint16_t height, PixelFormat_t format)
+static uint32_t get_image_data_size (uint16_t width, uint16_t height, PixelFormat_t format)
 {
     uint32_t data_size = 0;
 
-    // Create new image
-    Image_t * new_image = calloc(1, sizeof(Image_t));
-    if (!new_image) return NULL;
-
-    // Fill in width, height and pixel format
-    new_image->width = width;
-    new_image->height = height;
-    new_image->format = format;
-    new_image->data = NULL;
-
-    // Get data size based on format
     switch (format) {
-        default:
         case YUV444:
         case YUV444p:
         case RGB24:
@@ -37,7 +25,32 @@ Image_t * create_image (uint16_t width, uint16_t height, PixelFormat_t format)
         case ASCII:
             data_size = width * height;
             break;
+
+        default:
+            data_size = 0;
+            break;
     }
+
+    return data_size;
+}
+
+
+Image_t * create_image (uint16_t width, uint16_t height, PixelFormat_t format)
+{
+    uint32_t data_size = 0;
+
+    // Create new image
+    Image_t * new_image = calloc(1, sizeof(Image_t));
+    if (!new_image) return NULL;
+
+    // Fill in width, height and pixel format
+    new_image->width = width;
+    new_image->height = height;
+    new_image->format = format;
+    new_image->data = NULL;
+
+    // Get data size based on format
+    data_size = get_image_data_size(width, height, format);
 
     // Allocate the calculated size
     new_image->data = calloc(1, sizeof(uint8_t) * data_size);
@@ -54,4 +67,159 @@ void destroy_image (Image_t * img)
 {
     if (img->data) free(img->data);
     if (img) free(img);
+}
+
+
+uint8_t save_image (Image_t * img, const char * filepath)
+{
+    FILE * image_file = NULL;
+    size_t res = 0;
+    uint32_t data_size = 0;
+
+    if (!img) return 0;
+
+    image_file = fopen(filepath, "wb");
+    if (!image_file) return 0;
+
+    // Write the width, height and pixel format first.
+    res = fwrite(&img->width, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    res = fwrite(&img->height, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    res = fwrite(&img->format, sizeof(PixelFormat_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    // Write the raw image data.
+    data_size = get_image_data_size(img->width, img->height, img->format);
+    res = fwrite(img->data, sizeof(uint8_t), data_size, image_file);
+    if (res != data_size) {
+        fclose(image_file);
+        return 0;
+    }
+
+    fclose(image_file);
+
+    return 1;
+}
+
+
+Image_t * load_image (const char * filepath)
+{
+    FILE * image_file = NULL;
+    Image_t * img = NULL;
+    uint16_t width = 0;
+    uint16_t height = 0;
+    PixelFormat_t format = 0;
+    size_t res = 0;
+    uint32_t data_size = 0;
+
+    image_file = fopen(filepath, "rb");
+    if (!image_file) return NULL;
+
+    // Load the width, height and pixel format first.
+    res = fread(&width, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return NULL;
+    }
+
+    res = fread(&height, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return NULL;
+    }
+
+    res = fread(&format, sizeof(PixelFormat_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return NULL;
+    }
+
+    // Create the image structure.
+    img = create_image(width, height, format);
+
+    // Load the raw image data.
+    data_size = get_image_data_size(img->width, img->height, img->format);
+    res = fread(img->data, sizeof(uint8_t), data_size, image_file);
+    if (res != data_size) {
+        destroy_image(img);
+        fclose(image_file);
+        return NULL;
+    }
+
+    fclose(image_file);
+
+    return img;
+}
+
+
+uint8_t load_static_image (Image_t * img, const char * filepath)
+{
+    FILE * image_file = NULL;
+    uint16_t width = 0;
+    uint16_t height = 0;
+    PixelFormat_t format = 0;
+    size_t res = 0;
+    uint32_t data_size = 0;
+
+    if (!img) return 0;
+
+    image_file = fopen(filepath, "rb");
+    if (!image_file) return 0;
+
+    // Load the width, height and pixel format first.
+    res = fread(&width, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    res = fread(&height, sizeof(uint16_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    res = fread(&format, sizeof(PixelFormat_t), 1, image_file);
+    if (res != 1) {
+        fclose(image_file);
+        return 0;
+    }
+
+    // Check that the data we just read matches the expected image data.
+    if (width != img->width) {
+        fclose(image_file);
+        return 0;
+    }
+    if (height != img->height) {
+        fclose(image_file);
+        return 0;
+    }
+    if (format != img->format) {
+        fclose(image_file);
+        return 0;
+    }
+
+    // Load the raw image data.
+    data_size = get_image_data_size(img->width, img->height, img->format);
+    res = fread(img->data, sizeof(uint8_t), data_size, image_file);
+    if (res != data_size) {
+        fclose(image_file);
+        return 0;
+    }
+
+    fclose(image_file);
+
+    return 1;
 }

--- a/tests/test_image_save_and_load.c
+++ b/tests/test_image_save_and_load.c
@@ -1,0 +1,320 @@
+#include "cuts.h"
+
+#include "libuimg.h"
+
+#define TEST_WIDTH 200
+#define TEST_HEIGHT 300
+
+
+char * test_image_save_and_static_load ()
+{
+    uint32_t i = 0;
+    uint16_t width = TEST_WIDTH;
+    uint16_t height = TEST_HEIGHT;
+    uint8_t res = 0;
+    Image_t * img1 = NULL;
+    Image_t * img2 = NULL;
+
+    // Create YUV444 image
+    img1 = create_image(width, height, YUV444);
+    img2 = create_image(width, height, YUV444);
+
+    // Set image pixels to the appropriate values
+    for (i = 0; i < width * height * 3; i += 3) {
+        // Set Y, U, V values
+        img1->data[i    ] = 'Y';
+        img1->data[i + 1] = 'U';
+        img1->data[i + 2] = 'V';
+    }
+
+    // Save image
+    res = save_image(img1, "/tmp/yuv444.img");
+    CUTS_ASSERT(res == 1, "Could not save YUV444 image.");
+    destroy_image(img1);
+
+    // Load image
+    res = load_static_image(img2, "/tmp/yuv444.img");
+    CUTS_ASSERT(res == 1, "Could not load YUV444 image.");
+    CUTS_ASSERT(img2->width == width, "Width is wrong on loaded YUV444 image.");
+    CUTS_ASSERT(img2->height == height, "Height is wrong on loaded YUV444 image.");
+    CUTS_ASSERT(img2->format == YUV444, "Pixel format is wrong on loaded YUV444 image.");
+
+    for (i = 0; i < width * height * 3; i += 3) {
+        CUTS_ASSERT(img2->data[i    ] == 'Y', "'Y' element wrong for loaded YUV444 image.");
+        CUTS_ASSERT(img2->data[i + 1] == 'U', "'U' element wrong for loaded YUV444 image.");
+        CUTS_ASSERT(img2->data[i + 2] == 'V', "'V' element wrong for loaded YUV444 image.");
+    }
+
+    destroy_image(img2);
+
+    return NULL;
+}
+
+
+char * test_image_save_and_load ()
+{
+    uint32_t i = 0;
+    uint16_t width = TEST_WIDTH;
+    uint16_t height = TEST_HEIGHT;
+    uint8_t res = 0;
+    Image_t * img1 = NULL;
+    Image_t * img2 = NULL;
+
+    // Create YUV444 image
+    img1 = create_image(width, height, YUV444);
+
+    // Set image pixels to the appropriate values
+    for (i = 0; i < width * height * 3; i += 3) {
+        // Set Y, U, V values
+        img1->data[i    ] = 'Y';
+        img1->data[i + 1] = 'U';
+        img1->data[i + 2] = 'V';
+    }
+
+    // Save image
+    res = save_image(img1, "/tmp/yuv444.img");
+    CUTS_ASSERT(res == 1, "Could not save YUV444 image.");
+    destroy_image(img1);
+
+    // Load image
+    img2 = load_image("/tmp/yuv444.img");
+    CUTS_ASSERT(img2, "Could not load YUV444 image.");
+    CUTS_ASSERT(img2->width == width, "Width is wrong on loaded YUV444 image.");
+    CUTS_ASSERT(img2->height == height, "Height is wrong on loaded YUV444 image.");
+    CUTS_ASSERT(img2->format == YUV444, "Pixel format is wrong on loaded YUV444 image.");
+
+    for (i = 0; i < width * height * 3; i += 3) {
+        CUTS_ASSERT(img2->data[i    ] == 'Y', "'Y' element wrong for loaded YUV444 image.");
+        CUTS_ASSERT(img2->data[i + 1] == 'U', "'U' element wrong for loaded YUV444 image.");
+        CUTS_ASSERT(img2->data[i + 2] == 'V', "'V' element wrong for loaded YUV444 image.");
+    }
+
+    destroy_image(img2);
+
+    return NULL;
+}
+
+
+char * test_invalid_file_on_save ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+
+    img = create_image(TEST_WIDTH, TEST_HEIGHT, RGB565);
+    res = save_image(img, "");
+    CUTS_ASSERT(res == 0, "Empty image file name should fail on save.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_invalid_file_on_load ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+
+    img = load_image("");
+    CUTS_ASSERT(img == NULL, "Empty image file name should fail on load.");
+
+    img = create_image(TEST_WIDTH, TEST_HEIGHT, GRAYSCALE);
+    res = load_static_image(img, "");
+    CUTS_ASSERT(res == 0, "Empty image file name should fail on static load.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_unexpected_data_on_static_load ()
+{
+    size_t res = 0;
+    Image_t * img1 = NULL;
+    Image_t * img2 = NULL;
+
+    img1 = create_image(TEST_WIDTH, TEST_HEIGHT, YUV420p);
+    img2 = create_image(1, TEST_HEIGHT, YUV420p);
+
+    save_image(img1, "/tmp/yuv420p.img");
+    destroy_image(img1);
+
+    res = load_static_image(img2, "/tmp/yuv420p.img");
+    CUTS_ASSERT(res == 0, "Width should be wrong when loading image.");
+
+    destroy_image(img2);
+    img2 = create_image(TEST_WIDTH, 1, YUV420p);
+    res = load_static_image(img2, "/tmp/yuv420p.img");
+    CUTS_ASSERT(res == 0, "Height should be wrong when loading image.");
+
+    destroy_image(img2);
+    img2 = create_image(TEST_WIDTH, TEST_HEIGHT, GRAYSCALE);
+    res = load_static_image(img2, "/tmp/yuv420p.img");
+    CUTS_ASSERT(res == 0, "Format should be wrong when loading image.");
+
+    destroy_image(img2);
+
+    return NULL;
+}
+
+
+char * test_load_from_empty_file ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+    FILE * image_file = NULL;
+
+    // Create an empty binary file.
+    image_file = fopen("/tmp/empty.img", "wb");
+    fclose(image_file);
+
+    // Attempt to load an image from the empty file.
+    img = load_image("/tmp/empty.img");
+    CUTS_ASSERT(img == NULL, "Should not be able to load an image from an empty file.");
+    // Attempt to statically load an image from the empty file.
+    img = create_image(TEST_WIDTH, TEST_HEIGHT, YUV444);
+    res = load_static_image(img, "/tmp/empty.img");
+    CUTS_ASSERT(res == 0, "Should not be able to statically load an image from an empty file.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_load_from_file_missing_height ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+    uint16_t width = 1;
+    FILE * image_file = NULL;
+
+    // Create a binary file containing only the width of the image.
+    image_file = fopen("/tmp/missing_height.img", "wb");
+    fwrite(&width, sizeof(uint16_t), 1, image_file); 
+    fclose(image_file);
+
+    // Attempt to load an image from the incomplete file.
+    img = load_image("/tmp/missing_height.img");
+    CUTS_ASSERT(img == NULL, "Should not be able to load an image from a file that's missing its height.");
+    // Attempt to statically load an image from the incomplete file.
+    img = create_image(1, 2, YUV444);
+    res = load_static_image(img, "/tmp/missing_height.img");
+    CUTS_ASSERT(res == 0, "Should not be able to statically load an image from a file that's missing its height.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_load_from_file_missing_format ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+    uint16_t width = 1;
+    uint16_t height = 2;
+    FILE * image_file = NULL;
+
+    // Create a binary file containing only the width and the height of the image.
+    image_file = fopen("/tmp/missing_format.img", "wb");
+    fwrite(&width, sizeof(uint16_t), 1, image_file); 
+    fwrite(&height, sizeof(uint16_t), 1, image_file); 
+    fclose(image_file);
+
+    // Attempt to load an image from the incomplete file.
+    img = load_image("/tmp/missing_format.img");
+    CUTS_ASSERT(img == NULL, "Should not be able to load an image from a file that's missing its format.");
+    // Attempt to statically load an image from the incomplete file.
+    img = create_image(1, 2, YUV444);
+    res = load_static_image(img, "/tmp/missing_format.img");
+    CUTS_ASSERT(res == 0, "Should not be able to statically load an image from a file that's missing its format.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_load_from_file_missing_data ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+    uint16_t width = 1;
+    uint16_t height = 2;
+    PixelFormat_t format = YUV444;
+    FILE * image_file = NULL;
+
+    // Create a binary file containing only the width, height and the format of the image.
+    image_file = fopen("/tmp/missing_data.img", "wb");
+    fwrite(&width, sizeof(uint16_t), 1, image_file); 
+    fwrite(&height, sizeof(uint16_t), 1, image_file); 
+    fwrite(&format, sizeof(PixelFormat_t), 1, image_file); 
+    fclose(image_file);
+
+    // Attempt to load an image from the incomplete file.
+    img = load_image("/tmp/missing_data.img");
+    CUTS_ASSERT(img == NULL, "Should not be able to load an image from a file that's missing its data.");
+    // Attempt to statically load an image from the incomplete file.
+    img = create_image(1, 2, YUV444);
+    res = load_static_image(img, "/tmp/missing_data.img");
+    CUTS_ASSERT(res == 0, "Should not be able to statically load an image from a file that's missing its data.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * test_load_from_file_incomplete_data ()
+{
+    size_t res = 0;
+    Image_t * img = NULL;
+    uint16_t width = 1;
+    uint16_t height = 2;
+    PixelFormat_t format = YUV444;
+    uint8_t data[] = { 'Y', 'U', 'V' };
+    FILE * image_file = NULL;
+
+    // Create a binary file containing everything, but only write half of the pixel data it's supposed to have.
+    image_file = fopen("/tmp/missing_data.img", "wb");
+    fwrite(&width, sizeof(uint16_t), 1, image_file); 
+    fwrite(&height, sizeof(uint16_t), 1, image_file); 
+    fwrite(&format, sizeof(PixelFormat_t), 1, image_file); 
+    fwrite(data, sizeof(uint8_t), 3, image_file); 
+    fclose(image_file);
+
+    // Attempt to load an image from the incomplete file.
+    img = load_image("/tmp/incomplete_data.img");
+    CUTS_ASSERT(img == NULL, "Should not be able to load an image from a file that has incomplete pixel data.");
+    // Attempt to statically load an image from the incomplete file.
+    img = create_image(1, 2, YUV444);
+    res = load_static_image(img, "/tmp/incomplete_data.img");
+    CUTS_ASSERT(res == 0, "Should not be able to load an image from a file that has incomplete pixel data.");
+
+    destroy_image(img);
+
+    return NULL;
+}
+
+
+char * all_tests ()
+{
+    CUTS_START();
+
+    CUTS_RUN_TEST(test_image_save_and_static_load);
+    CUTS_RUN_TEST(test_image_save_and_load);
+    CUTS_RUN_TEST(test_invalid_file_on_save);
+    CUTS_RUN_TEST(test_invalid_file_on_load);
+    CUTS_RUN_TEST(test_unexpected_data_on_static_load);
+    CUTS_RUN_TEST(test_load_from_empty_file);
+    CUTS_RUN_TEST(test_load_from_file_missing_height);
+    CUTS_RUN_TEST(test_load_from_file_missing_format);
+    CUTS_RUN_TEST(test_load_from_file_missing_data);
+    CUTS_RUN_TEST(test_load_from_file_incomplete_data);
+
+    return NULL;
+}
+
+CUTS_RUN_SUITE(all_tests);


### PR DESCRIPTION
Functions are added to save and load images to and from binary files.
A `load_static_image` function is also added, in case any dynamic
allocations must be avoided; to use it, the user has to pass it a
pre-allocated image structure.